### PR TITLE
luojun's pretask

### DIFF
--- a/Intern/intern_message.md
+++ b/Intern/intern_message.md
@@ -98,6 +98,15 @@ github:@shafeipaozi
 
 邮箱: sunbo.oerv@isrc.iscas.ac.cn
 
+## 罗君
+
+gitee:@Jerry.c
+
+github:@Jer6y
+
+加入时间: 2023年12月30日
+
+邮箱: luojun.oerv@isrc.iscas.ac.cn
 
 # 项目实习生
 


### PR DESCRIPTION
- **任务一**
  - **任务描述:**  使用qemu-system-riscv64 启动openEuler 23.03 （使用官方镜像和官方脚本），并输出neofetch结果
  - **解决方案:**  在github 上搜索 neofetch，clone 下来，然后make install 就好，确保自己有GNU环境
  - **遇到的坑点:**  none ，注意把qemu-system-riscv环境安装好就可以了,然后记得在脚本里面调整占用资源的大小（我使用的是轻量级服务器，资源不是太多，所以得把占用的资源量改小）
![neofetch](https://github.com/openEuler-RISCV/oerv-team/assets/88422053/9c250f4a-c4d6-42e6-9e85-8fe2befb2b17)


- **任务二**

  - **任务描述:**  在openEuler-riscv-qemu内搭建osc本地环境，通过osc 拉取obs的pcre2包，构建RPM包
  - **解决方案:**  用dnf把osc 安装好了后，配置config, ~/.oscrc 就可了，然后从obs上把包拉下来，根据DOC里面进行构建
  - **遇到的坑点:** none , 注意一下.oscrc里面把DOC里面的注释去掉就好了
![USE_OSC_BUILD_pcre2](https://github.com/openEuler-RISCV/oerv-team/assets/88422053/e327f392-3476-4631-a75b-386bc23b4c0e)
  

- **任务三**

  - **任务描述:** 在本地host使用QEMU-USER 模式和systemd-nspawn 加速构建rpm包，host 为debian-12.0 
  - **解决方案:** 根据DOC里面的，利用源码构建好 qemu-user osc obs-build 安装好sytstemd-container 和zstd 
  - **遇到的坑点:**  ubuntu和debian的UU们需要注意的事项，以上源码构建的软件可以通过sudo apt install 来解决，但是请尽可能从源码上去构建, 在host为ubuntu22.04tls,apt的源为腾讯源时，下载的OSC工具版本比较低，不能支持osc build --vm-type=nspawn 在build启动nspawn容器的时候会出现一些问题
<img width="1120" alt="QEMU_USER+NSPAWN" src="https://github.com/openEuler-RISCV/oerv-team/assets/88422053/82512766-4b18-4b59-9bc7-00e86430f74c">
