### PR TITLE
实习生郝逸飞+创建邮箱

### DIFF
--- a/Intern/intern_message.md
+++ b/Intern/intern_message.md
@@ -88,6 +88,16 @@ github:@TimePrinciple
 
 邮箱: ruoqing@isrc.iscas.ac.cn
 
+## 郝逸飞
+
+gitee:@feifei-fertilizer
+
+github:@FeiFei0827
+
+加入时间: 2024年1月1日
+
+邮箱: yifei.oerv@isrc.iscas.ac.cn
+
 # 项目实习生
 
 <!-- 项目实习生添加格式:


### PR DESCRIPTION
# pretask1

1.安装qemu
2.拉下来openEuler
3.进入openEuler系统
4.安装运行相关的包/安装neofetch 
neofetch
![屏幕截图 2024-01-02 145236](https://github.com/openEuler-RISCV/oerv-team/assets/114592928/4ac56072-887e-4d3f-b205-439c3bde88e1)

# pretask2

注：这是我消耗时间最长的一个环节

主机我尝试过unbuntu manjaro arch 都没能构建

当然我第一个尝试的就是openEuler中构建包 但osc的安装一直有问题

遂尝试用主机

但由于我们构建的是riscv的相关包 需要有硬件环境支持 失败

## 以下是我当时遇到的问题

### 有关 oscbuild的相关问题

#### 环境

win11下VMware模拟的ubuntu22.04和manjaro（两者我都试了 现在的问题较为一致）

#### 进展

自认为 osc 拉取服务器的包应该没啥问题

![屏幕截图 2024-01-04 235356](https://github.com/openEuler-RISCV/oerv-team/assets/114592928/47b56414-0025-4c7f-8ff3-9b2f9c25e6b4)


如图，如果有问题还请告诉我

#### 问题

1

osc build出问题 按照提示使用osc build standard_riscv64 riscv64

则会出现以下error

![屏幕截图 2024-01-04 235629](https://github.com/openEuler-RISCV/oerv-team/assets/114592928/5854316c-7cd9-4dc2-b8dd-63fcaccc6c56)


这里是参考[使用 osc build 在本地构建 openEuler OBS 服务端的内容](https://gitee.com/zxs-un/doc-port2riscv64-openEuler/blob/master/doc/build-osc-obs-service.md)来进行操作

我也尝试过[oerv-pretask（二）在 openEuler RISC-V 系统上通过 obs 命令行工具 osc，从源代码构建 RISC-V 版本的 rpm 包，比如 coreutils](https://blog.csdn.net/weixin_52230326/article/details/135311782?spm=1001.2014.3001.5502)

以及[搭建openEuler本地osc编译环境并进行构建 - 知乎 (zhihu.com)](https://zhuanlan.zhihu.com/p/412515503)

都有类似的问题

我认为我很可能有很关键的地方疏忽了



我还参考过[基于 systemd-nspawn 和 QEMU User Mode 搭建 openEuler RISC-V 软件包的快速开发环境](https://zhuanlan.zhihu.com/p/528373554)

未果

2

我未能保存图片

以下是报错

0.0% cache miss. 275/275 dependencies cached.

Skipping verification of package signatures
Writing build configuration
Running build
logging output to /var/tmp/build-root/standard_riscv64-riscv64/.build.log...
[ 0s] Memory limit set to 12286338KB
[ 0s] Using BUILD_ROOT=/var/tmp/build-root/standard_riscv64-riscv64
[ 0s] Using BUILD_ARCH=riscv64
[ 0s]
[ 0s]
[ 0s] feifei-virtual-machine started "build xz.spec" at Thu Jan 4 02:38:52 UTC 2024.
[ 0s]
[ 0s]
[ 0s] processing recipe /home/feifei/test255/openEuler:Mainline:RISC-V/xz/xz.spec ...
[ 0s] running changelog2spec --target rpm --file /home/feifei/test255/openEuler:Mainline:RISC-V/xz/xz.spec
[ 1s] init_buildsystem --configdir /usr/lib/build/configs --cachedir /var/cache/build --clean --rpmlist /tmp/rpmlist.03993rec /home/feifei/test255/openEuler:Mainline:RISC-V/xz/xz.spec ...
[ 1s] Warning: cross compile not possible due to missing static binaries. please install build-initvm package for that purpose.
[ 1s] check that the right architecture is available for your build host, you need for this one.
[ 2s] cycle: filesystem -> bash
[ 2s] breaking dependency filesystem -> bash
[ 2s] cycle: rpm-libs -> rpm
[ 2s] breaking dependency rpm -> rpm-libs
[ 2s] [1/33] preinstalling libffi-devel...
[ 2s] [2/33] preinstalling filesystem...
[ 2s] [3/33] preinstalling glibc...
[ 2s] [4/33] preinstalling libatomic...
[ 2s] [5/33] preinstalling libatomic_ops...
[ 2s] [6/33] preinstalling libdb...
[ 3s] [7/33] preinstalling libgpg-error...
[ 3s] [8/33] preinstalling lz4...
[ 3s] [9/33] preinstalling pcre2...
[ 3s] [10/33] preinstalling xz-libs...
[ 3s] [11/33] preinstalling zlib...
[ 3s] [12/33] preinstalling zstd...
[ 3s] [13/33] preinstalling attr...
[ 3s] [14/33] preinstalling bash...
[ 3s] [15/33] preinstalling pesign-obs-integration...
[ 3s] [16/33] preinstalling selinux-policy-targeted...
[ 4s] [17/33] preinstalling bzip2...
[ 4s] [18/33] preinstalling cmake...
[ 5s] [19/33] preinstalling compat-openssl11-libs...
[ 5s] [20/33] preinstalling libacl...
[ 5s] [21/33] preinstalling libcap...
[ 5s] [22/33] preinstalling libgcrypt...
[ 5s] [23/33] preinstalling libselinux...
[ 5s] [24/33] preinstalling lua...
[ 5s] [25/33] preinstalling openssl-libs...
[ 5s] [26/33] preinstalling popt...
[ 6s] [27/33] preinstalling iproute...
[ 6s] [28/33] preinstalling systemd-libs...
[ 6s] [29/33] preinstalling rpm...
[ 6s] [30/33] preinstalling dbus-libs...
[ 6s] [31/33] preinstalling dhcp...
[ 6s] [32/33] preinstalling rpm-libs...
[ 6s] [33/33] preinstalling digest-list-tools...
[ 6s] initializing rpm db...
[ 7s] chroot: failed to run command '/usr/bin/rpmdb': Exec format error
[ 7s]
[ 7s] feifei-virtual-machine failed "build xz.spec" at Thu Jan 4 02:38:59 UTC 2024.
[ 7s]

Build failed with exit code 1
The buildroot was: /var/tmp/build-root/standard_riscv64-riscv64

Cleaning the build root may fix the problem or allow you to start debugging from a well-defined state:

- add '--clean' option to your 'osc build' command
- run 'osc wipe [--vm-type=...]' prior running your 'osc build' command again

**我的尝试** 按照提示 --clean 无果



**疑点**

这里第一次提示的是 100.0% cache miss. 0/275 dependencies cached.

伴随着下面一些有关api的提

再次运行便是 0.0% cache miss. 275/275 dependencies cached

猜想这里可能没有正确拉取

## 解决

osc 与osc build没有问题 oscrc的设置有些许问题

以及构建riscv相关包要在openEuler中

不用直接 osc build

应使用 osc build standard-riscv64 riscv64

否则会默认构建错误架构
![屏幕截图 2024-01-05 133453](https://github.com/openEuler-RISCV/oerv-team/assets/114592928/efca83be-b6cb-413f-bfd6-45e90507df56)



## 总结

同事们给我了许多的帮助以及提示 推荐我看博客 看视频等等 给我解决问题 提供了思路

虽然现在回想起来饶了很多远路 花费了很多时间 却让我对obs有了更深的了解 这也不是坏事 

# pretask3

这个由于看了博客 很快就做了出来

在qemu目录中运行

``sudo ./scripts/qemu-binfmt-conf.sh --persistent yes --credential yes --systemd riscv64`
`sudo systemctl restart systemd-binfmt`` 

安装后检查

`sudo systemctl status systemd-binfmt.service`

输出的状态为active（绿色） 成功

进入openEuler和之前一样拉包构建

这次需要

`osc build standard_riscv64 riscv64 --vm-type=chroot`
![屏幕截图 2024-01-05 152856](https://github.com/openEuler-RISCV/oerv-team/assets/114592928/d8459fc3-dd4c-45c4-b64f-f47078434387)


这里虽然加速了但是却比不加速还要慢

我认为是因为我在等待的过程中玩了下游戏导致内存占用过高。。。。。

但是也是成功了



完结撒花
#所有的任务截图如下

![屏幕截图 2024-01-02 145236](https://github.com/openEuler-RISCV/oerv-team/assets/114592928/a8eebd2f-a6f2-44cd-bea1-ea4d453d4b37)

![屏幕截图 2024-01-05 133453](https://github.com/openEuler-RISCV/oerv-team/assets/114592928/efca83be-b6cb-413f-bfd6-45e90507df56)
![屏幕截图 2024-01-05 152856](https://github.com/openEuler-RISCV/oerv-team/assets/114592928/f9b4dfe5-9c4a-4517-858a-24c4514324bd)
