### PR TITLE
实习生温若涵+创建邮箱

### DIFF
--- a/Intern/intern_message.md
+++ b/Intern/intern_message.md
@@ -99,9 +99,9 @@ github:@FeiFei0827
 邮箱: yifei.oerv@isrc.iscas.ac.cn
 
 ## 温若涵
-gitee: @Wenrh2004
+gitee: @KingYen
 
-github: @KingYen
+github: @Wenrh2004
 
 加入时间: 2024年1月24日
 


### PR DESCRIPTION
# `pretask` 完成情况
## Task I 通过 QEMU 仿真 RISC-V 环境并启动 openEuler RISC-V 系统，设法输出 neofetch 结果并截图提交
- **Local Operation**
  > local environment：
  > - MacOS Sonoma 14.2.1 (23C71)
  > - Apple M1 Pro
  > target environment:
  > - openEuler-23.09-RISC-V
  **running mode**
  ```bash
  wget -c https://github.com/dylanaraps/neofetch/archive/refs/tags/7.1.0.tar.gz
  tar -xvf 7.1.0.tar.gz
  cd neofetch-7.1.0
  ./neofetch
  ```
  > **running result**
<img width="1624" alt="截屏2024-01-24 22 11 12" src="https://github.com/openEuler-RISCV/oerv-team/assets/122615371/c363ee68-9b10-41e5-8099-fcd3a9841561">

- **Cloud Service operation**  
  > local environment：  
  > - Alibaba Cloud Linux release 3 (Soaring Falcon) x86_64  
  > - Intel Xeon Platinum (4) @ 2.500GHz  
  > target environment:  
  > - openEuler-22.003-LTS-RISC-V  
  > <img width="1624" alt="截屏2024-01-25 12 18 24" src="https://github.com/openEuler-RISCV/oerv-team/assets/122615371/624a9a5d-da81-4b11-ace3-1581f7d39f74">  
  **running mode**
   - docker run Ubuntu  
  <img width="1624" alt="截屏2024-01-24 23 26 15" src="https://github.com/openEuler-RISCV/oerv-team/assets/122615371/dd617cc3-39e9-4209-b457-68ff1b7e57c3">

  - Install qemu and openEuler-22.03-LTS-RISC-V image  

  - run openEuler-22.03-LTS-RISC-V image by qemu-system-riscv64  

  - Install neofetch  

  - Since aliyun's access to GitHub is unstable, switching to gitee  
  > **running result**  
  <img width="1624" alt="截屏2024-01-25 11 44 06" src="https://github.com/openEuler-RISCV/oerv-team/assets/122615371/f2e398e1-fa94-477f-a6d8-cb37e6b614d3">

## Task II 在 openEuler RISC-V 系统上通过 obs 命令行工具 osc，从源代码构建 RISC-V 版本的 rpm 包，比如 pcre2。
> local environment：  
  > - Alibaba Cloud Linux release 3 (Soaring Falcon) x86_64  
  > - Intel Xeon Platinum (4) @ 2.500GHz  
  > target environment:  
  > - openEuler-22.003-LTS-RISC-V  
  > <img width="1624" alt="截屏2024-01-25 12 18 24" src="https://github.com/openEuler-RISCV/oerv-team/assets/122615371/624a9a5d-da81-4b11-ace3-1581f7d39f74">
- Configuration OBS and OSC
  - Sign In OBS
  - Install OCS
  - Configure the OSC
  ```bash
  vim ~/.oscrc
  ```
  ```markdown
  [general]
  apiurl = https://build.openeuler.openatom.cn/
  [https://build.openeuler.openatom.cn/]
  user=userName
  pass=passWord
  ```
- Creating a Project
  - Creating Branches by ourself
  ```bash
  osc branch openEuler: 23.09 :RISC-V pcre2
  ```
  - Copy ourself branches
  ```bash
  osc co home:KingYen. :branches: openEuler:23.09 :RISC-V/pcre2
  ```
  - Install the project file
  ```bash
  cd home:KingYen. :branches: openEuler:23.09 :RISC-V/pcre2 && osc up -S
  ```
- Build an RPM Package
  - Remove the file header
  ```bash
  rm -f _service;for file in 'ls | grep -v osc ;do new_file=${file##*:};mv $file $new_file;done osc addremove *
  ```

<img width="1624" alt="截屏2024-01-25 04 05 07" src="https://github.com/openEuler-RISCV/oerv-team/assets/122615371/0b67ff86-be0f-4905-b5cf-0bcca425fb4b">

  - update the file
  ```bash
  osc up
  ```
  - Commit the file
  ```bash
  osc ci -m "commit log"
  ```
  - command to obtain the repository name and architecture of the current project
  ```bash
  osc repos home:KingYen. :branches: openEuler:23.09 :RISC-V/pcre2
  ``` 

<img width="1624" alt="截屏2024-01-25 04 04 36" src="https://github.com/openEuler-RISCV/oerv-team/assets/122615371/ef07b116-c6dc-4c1b-b04f-791b0e6b99d4">

  - build the project
  ```bash
  osc buildlog standard_riscv64 riscv64
  ```
<img width="1624" alt="截屏2024-01-25 04 05 55" src="https://github.com/openEuler-RISCV/oerv-team/assets/122615371/487e47e2-897e-42bc-98e1-cd262813fa46">
<img width="1624" alt="截屏2024-01-25 04 31 40" src="https://github.com/openEuler-RISCV/oerv-team/assets/122615371/f804429d-6aa1-40e3-a63e-14c2c516a56b">

## Task III 尝试使用 qemu user & nspawn 或者 docker 加速完成任务二
Personally, I'm more familiar with docker, so I used docker-compose to build it, and I also chose to use the full openEuler-22.03-LST-RISC-V as the docker image for ease of building.

---

# Problem in pretask
In the openEuler-23.09-RISC-V version, the osc download source was missing, so a build by source compilation was used.
However, during the execution of `. /install.py`, I encountered `error: Couldn't find a setup script in /tmp/easy_install-ecjx7xra/cryptography-42.0.0.tar.gz`, and switched to `pip` for the problematic libraries. In `pip install cryptography`, I encountered the error `src/c/_cffi_backend.c:2:10: fatal error: Python.h: No such file or directory`, I personally deduced that a series of errors caused by the lack of `Python.h`, can be used to Adding the missing file to the relevant package has not yet been attempted.