### PR TITLE
lijinzhe case：add case about package issues having to do with symbol/feature check …

### DIFF
--- a/cases/2024.4.16-SymbolCheck2CompileFailed-李金哲.md
+++ b/cases/2024.4.16-SymbolCheck2CompileFailed-李金哲.md
@@ -1,0 +1,45 @@
+# 问题描述：因为构建工具check symbol/feature失败导致后续编译失败
+
+
+## 具体问题
+- 许多构建工具（如cmake，meson或者自定义脚本等）会在构建前进行检查，包括
+  - 源码是否定义指定symbol（如宏定义，结构体，类型等）
+  - 当前使用的工具链是否启用指定特性（如当前cxx编译器是否支持C17标准）
+- 检查是否通过本身不是问题，问题是工具的误判，检查结果对构建工具的误导可能进一步导致后续编译失败。
+- 误判的原因和检查方式有关，核心的检查逻辑非常简单：**生成一个临时文件，在文件中使用需要检查的符号/特性，然后编译，检查编译器输出的warning/error**。如果编译器输出了与符号/特性无关，但是构建工具不理解的打印，很可能会导致工具的误判。
+- 本案例以zip/cmake/dpdk修包为例对check symbol/feature导致compile failed的问题进行分析
+
+## zip: clang-error Wimplicit-function-declaration
+### 问题表现
+- zip在构建时因为symbol redefine（如string.h中的字符串操作函数）编译失败。zip自定义的函数和libc原有的产生了冲突，问题在于为什么zip会在libc有函数实现时重新定义一套。
+### 问题分析
+- [zip合入的pr](https://gitee.com/src-openeuler/zip/pulls/33)
+- zip的unix/configure脚本会检查当前系统是否安装了某些依赖和满足某些特性，完全基于linux提供的echo等工具实现临时文件的创建，编译和结果检查，非常简单
+- 为了确保简单，脚本创建的临时文件中没有任何的include，对于gcc和老版本的clang默认编译选项下只是在编译c文件时找不到声明产生warning，不会产生error
+- 但是在[clang version >= 16中引入了一些新的error](https://www.redhat.com/en/blog/new-warnings-and-errors-clang-16)，其中就有**Wimplicit-function-declaration**，它会将未声明视为错误，而且默认启用。导致zip在编译临时文件因为该错误失败，误判符号不存在并重新定义了一次，最终导致编译时redefine的错误
+### 解决方案
+- 在zip编译临时文件时不启用该error，避免zip误判而自定义函数，导致与libc冲突。
+
+## cmake: cm_cxx_features() and clang-warning Wunused-command-line-argument
+### 问题表现
+- [cmake-3.27.9在构建时检查compiler是否支持C11特性（如unique_ptr）失败](https://gitlab.kitware.com/cmake/cmake/uploads/180d0f4967857809bf35ebfbe71f224f/image.png)，不继续执行编译
+### 问题分析
+- 查看源码，cmake最终是通过Source/Checks/cm_cxx_features.cmake中的**cm_cxx_features()方法**对CXX特性进行检查，其中的核心是**try_run/try_compile**方法。
+- 我认为它们与zip的检查方法没有本质的区别，还是通过生成临时文件进行编译完成
+- cmake会将try_run/compile的输出储存到output中，并且**会用正则表达式过滤cmake认为与特性无关的warining**，然后再检查output中是否还有warning/error，cmake对gcc的warning的过滤适配的比较好。
+- clang有一个Wunused-command-line-argument的warning没有在过滤规则中，所以output中未过滤该warning，导致cmake认为该warning出现说明不支持当前特性，检查失败
+### 解决方案
+- 在cm_cxx_features中增加过滤Wunused-command-line-argument warning的条件，因为该warning与cxx特性是否支持无关
+
+## dpdk: meson check symbol failed and kernel module build error
+### 问题表现
+- [dpdk的pr，尚未合入](https://gitee.com/src-openeuler/dpdk/pulls/539)
+- 类似zip，dpdk因为检查符号时判断符号不存在，重新定义了一遍符号，在实际编译dpdk时因为symbol redefine的问题导致失败
+### 问题分析
+- dpdk和zip类似，在编译时会检查指定的符号。但是dpdk的问题是最玄学的，因为它用meson进行项目管理和构建，meson提供了接口用于判断符号，结构体成员等是否存在。
+- 猜测meson在检查符号和编译时使用的是同一套的ld/cflags和工具链，因为meson在调用接口时没有显示的传入ld/cflags
+- 然后meson因为错误的ldflags（gcc可用，但是clang不可用，切换工具链到LLVM产生的问题）在编译用于检查符号的临时文件时编译失败，导致meson误判符号不存在，最终导致编译失败
+- 另一方面，dpdk构建时需要编译内核模块，编译内核模块时需要用到kernel config，但是测试时环境是gcc构建的，会启用一些仅gcc可使用的编译选项，所以使用clang编译内核模块失败
+### 解决方案
+- 如果工具链是LLVM，则需要将clang无法识别的ldflags过滤掉
+- dpdk构建必须要确保使用的工具链和编译内核时使用的保持一致（涉及编译内核模块时均需要进行考虑）


### PR DESCRIPTION
总结了一下修复zip/dpdk/cmake包的过程存在共性问题，都属于因为检查符号是否存在/是否支持特性失败导致构建失败