### PR TITLE
实习生黄丕松+创建邮箱

### DIFF
--- a/Intern/intern_message.md
+++ b/Intern/intern_message.md
@@ -242,3 +242,13 @@ github: @moumoulongs
 加入时间: 2024年5月22日
 
 邮箱: <danlong.oerv@isrc.iscas.ac.cn>
+
+## 黄丕松
+
+gitee: @cpntroller
+
+github: @1291945816
+
+加入时间: 2024年6月5日
+
+邮箱: <pisong.oerv@isrc.iscas.ac.cn>


### PR DESCRIPTION
### 壹·任务一

启动镜像，并远程`openEuler`虚拟机：

1. 启动镜像：`./start_vm.sh`
2. 主机侧远程:`ssh root@192.128.122.120 -p 12055`
![image-20240606004313316](https://github.com/openeuler-riscv/oerv-team/assets/44140668/0fef6c7a-ef5b-4573-a9d4-914ca27d0b6d)


>前期已经把对应的镜像文件下到本地，本次不重复相关下载过程。

直接从源安装: `dnf install neofetch`

![task01-1](https://github.com/openeuler-riscv/oerv-team/assets/44140668/ab224d29-7791-4ce6-998b-2f2492f07b3a)


**提示：没找到对应的包，说明仓库并没有构建好的包**

前往开源仓库，对应的[Wiki 文档](https://github.com/dylanaraps/neofetch/wiki/Installation#latest-git-master-bleeding-edge)提供了几种方案：

- 编译安装：https://github.com/dylanaraps/neofetch/wiki/Installation#universal-install
- 针对特定发行版制作的`neofetch`包：https://github.com/dylanaraps/neofetch/wiki/Installation#osdistro-packages

鉴于在仓库中没有这个包，选择第一种方案：

1. 安装`git`并配好相关的公钥便于后续的`clone`操作：`dnf install git`
2. `clone`仓库源码：`git clone https://github.com/dylanaraps/neofetch  `

进入到目录后，发现一个可执行的脚本文件，直接执行即可：

![neo](https://github.com/openeuler-riscv/oerv-team/assets/44140668/cee7bfde-a750-4261-aac1-f62a20f84eed)


### 贰·任务二

前往https://build.openeuler.openatom.cn/ 注册账户。

安装`osc`：`dnf install osc`

第一次执行`osc`对应的指令时，发现没配置账户信息，遂进行登录：

![task02](https://github.com/openeuler-riscv/oerv-team/assets/44140668/4db5c222-e806-4a66-8126-b66191612d74)


>此处输入账户信息会报`401`错误，查资料发现其实是api接口不对，账户注册的信息并不在`api.opensuse.org`上。

需要修改osc的账户配置信息以及具体的api地址:

```ini
[general]
apiurl = https://build.openeuler.openatom.cn
no_verify = 1

[https://build.openeuler.openatom.cn]
user=your username
pass=your passwd
credentials_mgr_class=osc.credentials.ObfuscatedConfigFileCredentialsManager
```

配置完信息后，再次执行`osc ll | grep psomng`查看OBS 服务器上个人的源信息：

![image-20240606202737673](https://github.com/openeuler-riscv/oerv-team/assets/44140668/fbd5ab24-b584-46c7-999e-0f32925b98cb)


选择`home:pSomng:branches:openEuler:Mainline:RISC-V`这个项目中的`curl`进行构建：` osc co home:pSomng:branches:openEuler:Mainline:RISC-V/curl`

![task02-4](https://github.com/openeuler-riscv/oerv-team/assets/44140668/4d9e2898-4f20-495e-91b2-8917568d9531)


从OBS 服务器中获取源码:`osc up -S`

![task02-3](https://github.com/openeuler-riscv/oerv-team/assets/44140668/1ae8a7aa-5b21-4d17-a4d7-b527ca544b28)


直接进行构建：`osc build --local-package standard_riscv64 riscv64 `,会提示缺少`build`的。

再执行：`dnf install build`即可。

然后再重新执行构建：

![task02-6](https://github.com/openeuler-riscv/oerv-team/assets/44140668/2c09f7de-c004-41ac-ac48-51420198e4a0)




### 叁·任务三

选择使用`docker`进行加速任务二的构建，所以需要在主机侧环境上安装并配置`osc`以及`docker`。

>这里特别容易陷入误区，就是以为在qemu仿真的环境里去安装`docker`进行加快构建。但其实不然，`docker`本质上也是提供一种虚拟化的环境，与`qemu`应该在构建过程中的级别是一样的，区别在于：一个是先进行`qemu`虚拟架构后，再利用本地架构构建软件包，而另一个是 本地采用`docker`进行构建。个人感觉来说，毕竟`qemu-system*`是系统级仿真，性能更低。

执行`osc build --local-package standard_riscv64 riscv64 --vm-type=docker`采用`docker`加速构建，可能会报以下错误：

![task03-5](https://github.com/openeuler-riscv/oerv-team/assets/44140668/ba4781b5-32ae-4c55-9ae8-9566ca016927)


这里的原因是`perl`缺少了`Data-Dumper`模块，手动编译一个即可：

```shell
wget https://www.cpan.org/modules/by-module/Data/Data-Dumper-2.173.tar.gz
tar -zxvf Data-Dumper-2.173.tar.gz
 cd Data-Dumper-2.173
 perl Makefile.PL
 make
 make install
```

然后再次构建即可：

![image-20240606211044770](https://github.com/openeuler-riscv/oerv-team/assets/44140668/44b53616-3caa-47a0-bd52-e9cce758efdc)


**相比第二次构建来说，显然这次的时间缩短了接近4倍。**