### PR TITLE
实习生顾凯杰+创建邮箱

### DIFF
--- a/Intern/intern_message.md
+++ b/Intern/intern_message.md
@@ -273,3 +273,12 @@ github：@YingkaiLi-VM
 
 邮箱：<yingkai.oerv@isrc.iscas.ac.cn>
 
+## 顾凯杰
+
+gitee：@gukaijie
+
+github：@gukj-spel
+
+加入时间：2024年9月5日
+
+邮箱：


### PR DESCRIPTION
## OpenEuler 实习-PreTask

### 软硬件环境

#### 硬件环境

CPU: intel x86_64 位

Memory: 16GB

#### 宿主机环境

ubuntu 22.04 WSL 



### 前置条件

需要安装 qemu ，并使用 qemu 运行 openEuler 系统。

- qemu 下载地址：[QEMU](https://www.qemu.org/download/)
- openEuler24.03 RISC-V 镜像下载地址： [openEuler-24.03-LTS](https://repo.openeuler.org/openEuler-24.03-LTS/virtual_machine_img/riscv64/)

#### qemu 编译安装

```
wget https://download.qemu.org/qemu-8.1.2.tar.xz
tar -xvf qemu-8.1.2.tar.xz
cd qemu-8.1.2
mkdir res
cd res
sudo apt install libspice-protocol-dev libepoxy-dev libgtk-3-dev libspice-server-dev build-essential autoconf automake autotools-dev pkg-config bc curl gawk git bison flex texinfo gperf libtool patchutils mingw-w64 libmpc-dev libmpfr-dev libgmp-dev libexpat-dev libfdt-dev zlib1g-dev libglib2.0-dev libpixman-1-dev libncurses5-dev libncursesw5-dev meson libvirglrenderer-dev libsdl2-dev -y
../configure --target-list=riscv64-softmmu,riscv64-linux-user --prefix=/usr/local/bin/qemu-riscv64 --enable-slirp
make -j$(nproc)
sudo make install
```

上述指令会将 QEMU 安装到 `/usr/local/bin/qemu-riscv64`。将 `/usr/local/bin/qemu-riscv64/bin` 添加至 `$PATH` 即可使用。

#### openEuler 启动

使用 start_vm.sh 启动镜像。 截取下 start_vm.sh 脚本的一部分，上面配置 PATH 和 LD_LIBRARY_PATH 

~~~shell
export PATH=/usr/local/bin/qemu-riscv64/bin:$PATH
export LD_LIBRARY_PATH=/usr/local/bin/qemu-riscv64/lib/x86_64-linux-gnu:$LD_LIBRARY_PATH

cmd="qemu-system-riscv64 \
  -nographic -machine virt,pflash0=pflash0,pflash1=pflash1,acpi=off \
  -smp "$vcpu" -m "$memory"G \
  -object memory-backend-ram,size=4G,id=ram1 \
  -numa node,memdev=ram1 \
  -object memory-backend-ram,size=4G,id=ram2 \
  -numa node,memdev=ram2 \
  -blockdev node-name=pflash0,driver=file,read-only=on,filename="$fw1" \
  -blockdev node-name=pflash1,driver=file,filename="$fw2" \
  -drive file="$drive",format=qcow2,id=hd0 \
  -object rng-random,filename=/dev/urandom,id=rng0 \
  -device virtio-vga \
  -device virtio-rng-device,rng=rng0 \
  -device virtio-blk-device,drive=hd0,bootindex=1 \
  -device virtio-net-device,netdev=usernet \
  -netdev user,id=usernet,hostfwd=tcp::"$ssh_port"-:22 \
  -device qemu-xhci -usb -device usb-kbd -device usb-tablet"
~~~



### 任务一 

> 通过 QEMU 仿真 RISC-V 环境并启动 openEuler RISC-V 系统，设法输出 neofetch 结果并截图提交

openeuler 无法直接通过 yum 安装 neofetch, 可以直接下载可执行文件压缩包来安装。 参考 [openEuler系统下neofetch 安装)](https://cloud.tencent.com/developer/article/2442853) 这篇教程。

~~~shell
 wget -c https://github.com/dylanaraps/neofetch/archive/refs/tags/7.1.0.tar.gz
 tar -xvf 7.1.0.tar.gz
 ln -s  ~/downloads/neofetch-7.1.0/neofetch  /usr/bin/neofetch #创建软链接
~~~

使用 neofetch 在终端打印发行版信息。

![image-20240904104214849](http://gu-typora-picture.oss-cn-beijing.aliyuncs.com/img/image-20240904104214849.png)



### 任务二

> 在 openEuler RISC-V 系统上通过 obs 命令行工具 osc，从源代码构建 RISC-V 版本的 rpm 包，比如 `pcre2`。（提示首先需要在 openEuler的 OBS[什么是 OBS？](https://github.com/openeuler-riscv/oerv-team/blob/main/Intern/FAQ.md#什么是-obs) 上注册账号  https://build.openeuler.openatom.cn/project/show/openEuler:Mainline:RISC-V）

#### 环境准备

在 obs 上注册账号。 obs 网站 [EulerMaker (openatom.cn)](https://eulermaker.compass-ci.openeuler.openatom.cn/) 或者 [Welcome - 开源软件构建与测试 (isrc.ac.cn)](https://build.tarsier-infra.isrc.ac.cn/)

安装 obs 客户端工具 osc： `dns install osc` 

配置 osc：使用 `osc who` 查看配置。发生报错。报错信息如下：

> , '[SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: certificate is not yet valid (_ssl.c:1006)'))) - skipping
> [root@localhost ~]# sudo update-ca-certificates --fresh

找到一篇问答  [[Solved\] SSL certificate problem: certificate is not yet valid ](https://bbs.archlinux.org/viewtopic.php?id=266777)  说可能因为时钟问题，导致 SSL 认证失败。使用 `timedatectl` 查看时钟

~~~shell
#openEuler
[root@localhost downloads]# timedatectl
               Local time: Sat 2024-04-20 14:31:20 UTC
           Universal time: Sat 2024-04-20 14:31:20 UTC
                 RTC time: Sat 2024-04-20 14:31:21
                Time zone: UTC (UTC, +0000)
System clock synchronized: no
              NTP service: n/a
          RTC in local TZ: no
#宿主机 wsl
gu@LAPTOP-N555J8SQ:~/downloads$ timedatectl
               Local time: Wed 2024-09-04 20:12:13 CST
           Universal time: Wed 2024-09-04 12:12:13 UTC
                 RTC time: Wed 2024-09-04 12:12:13
                Time zone: Asia/Shanghai (CST, +0800)
System clock synchronized: yes
              NTP service: inactive
          RTC in local TZ: no
~~~

果然是因为时钟不同步问题。使用 `timedatactl set-ntp true` 设置时钟同步，报错

~~~shell
Failed to set ntp: NTP not supported
~~~

这是因为没有 NTP 服务，使用 `yum install systemd-timesyncd` 安装 NTP 服务。安装后运行下列命令

~~~shell
[root@localhost downloads]# timedatectl set-ntp true
[root@localhost downloads]# timedatectl
               Local time: Wed 2024-09-04 12:17:47 UTC
           Universal time: Wed 2024-09-04 12:17:47 UTC
                 RTC time: Sat 2024-04-20 14:40:58
                Time zone: UTC (UTC, +0000)
System clock synchronized: yes
              NTP service: active
          RTC in local TZ: no
~~~

时钟同步完毕，之后运行 osc who 配置客户端信息。配置文件默认在 ` ~/.config/osc/oscrc`。 也可以手动创建该文件，配置信息如下

~~~wiki
[general]
# Default URL to the API server.
# Credentials and other `apiurl` specific settings must be configured in a `[$apiurl]` config section.
apiurl= https://build.tarsier-infra.isrc.ac.cn/
no_verify=1

[https://build.tarsier-infra.isrc.ac.cn/]
# aliases=
# user=
# pass=
# credentials_mgr_class=osc.credentials...
user=username
pass=password
~~~

配置完成后，重新运行 `osc who` 查看配置。

~~~shell
[root@localhost downloads]# osc who
ggukkj: "ggukkj" <2459548460@qq.com>
~~~



#### 构建 rpm

本次构建的 rpm 为 `man-db`，运行下列命令进行构建操作。

~~~shell
osc co openEuler:24.03/man-db #拉取软件包配置目录，在本地会创建一个相同目录
cd openEuler:24.03/man-db
osc up -S man-db #这一步是更新文件，如果没有更新源码和spec文件可以不执行
rm -f _service;for file in `ls`;do new_file=${file##*:};mv $file $new_file;done #重命名文件，删除_service 前缀
osc build --local-package mainline_riscv64 riscv64
~~~

构建结果如下：

![](http://gu-typora-picture.oss-cn-beijing.aliyuncs.com/img/image-20240904222843993.png)



### 任务三

> 尝试使用 qemu user & nspawn 或者 docker 加速完成任务二

对于 qemu user mode 和` nspawn `工具 不太清楚，做这个任务之前需要先了解以下

**qemu user mode**

援引 GPT 的介绍

> 在 QEMU 用户模式下，QEMU 只模拟用户空间的 CPU 指令和部分系统调用。它不会虚拟化整个操作系统，而是让应用程序运行在主机的用户空间中。QEMU 会拦截和翻译目标架构的系统调用，并将其转换为主机架构可以理解的系统调用。这样，应用程序就可以在与其编译架构不同的主机上运行。

**nspawn**

继续援引 GPT 的介绍

> `systemd-nspawn` 是 `systemd` 提供的一个轻量级容器工具，类似于 `chroot`，但功能更强大。它允许你在隔离的环境中运行操作系统或应用程序，主要用于开发、测试、或运行受限的容器化应用。与 `Docker` 相比, `systemd-nspawn` 更轻量，但功能不如 Docker 丰富，主要用于轻量级的隔离和快速的开发测试场景。



#### 安装 `qemu` user mode & `systemd-nspawn` 环境

##### 编译 `qemu` user mode

首先安装依赖

~~~shell
sudo apt install libspice-protocol-dev libepoxy-dev libgtk-3-dev libspice-server-dev build-essential autoconf automake autotools-dev pkg-config bc curl gawk git bison flex texinfo gperf libtool patchutils mingw-w64 libmpc-dev libmpfr-dev libgmp-dev libexpat-dev libfdt-dev zlib1g-dev libglib2.0-dev libpixman-1-dev libncurses5-dev libncursesw5-dev meson libvirglrenderer-dev libsdl2-dev -y
~~~

拉取 `qemu` 源码，并进行编译

~~~shell
git clone https://github.com/qemu/qemu.git
cd qemu
./configure --static \
  --enable-attr --enable-tcg --enable-linux-user --target-list=riscv64-linux-user \
  --without-default-devices --without-default-features --disable-install-blobs \
  --disable-debug-info --disable-debug-tcg --disable-debug-mutex --prefix=your_install_prefix
make -j$(nproc)
sudo make install
~~~

配置 `qemu` 运行路径

~~~shell
export PATH=$your_install_binary_path:$PATH
~~~

重新启动 `systemd-binfmt` 服务。

~~~shell
sudo systemctl restart systemd-binfmt.service
~~~

##### 下载 `systemd-nspawn` 

~~~shell
sudo apt install systemd-container systemd-nspawn
~~~



#### 编译安装 `osc` 和 `obs`

`osc`

~~~shell
git clone https://github.com/openSUSE/osc.git
cd osc
chmod +x setup.py
./setup.py build
sudo ./setup.py install
~~~

`obs`

~~~shell
git clone https://github.com/openSUSE/obs-build.git
cd obs-build
sudo make install
~~~



#### 编译构建 rpm 包

同样选择 `man-db` 进行构建。构建命令与任务二相同。运行后报错

~~~shell
[   26s] Warning: cross compile not possible due to missing static binaries. please install build-initvm package for that purpose.
[   26s]          check that the right architecture is available for your build host, you need  for this one.
[   26s] booting docker...
[   26s] chroot: can't execute '/.build/build': Exec format error
~~~

这个问题困扰了我好久， 我一开始以为是因为平台的问题。但是我手动执行命令却可以执行。 最后发现，原来是因为我的 `systemd-binfmt ` 无法正常运行。这是因为我再安装 `qemu user mode` 的时候手动指定了安装路径，运行 `systemd-binfmt` 用的是默认错误的 `qemu`。 这里需要通过 `export` 命令配置以下运行路径。配置完后使用 `systemctl` 重启下 `systemd-binfmt`。  这里感谢陈志康同事在他的 pr 里面留下的宝贵经验 [实习生陈志康+创建邮箱 ](https://github.com/openeuler-riscv/oerv-team/pull/292) 。上述配置好后，查看 `systemd-binfmt` 运行状态。

~~~shell
● systemd-binfmt.service - Set Up Additional Binary Formats
     Loaded: loaded (/lib/systemd/system/systemd-binfmt.service; static)
     Active: active (exited) since Thu 2024-09-05 21:33:20 CST; 8min ago
       Docs: man:systemd-binfmt.service(8)
             man:binfmt.d(5)
             https://www.kernel.org/doc/html/latest/admin-guide/binfmt-misc.html
             https://www.freedesktop.org/wiki/Software/systemd/APIFileSystems
    Process: 17543 ExecStart=/lib/systemd/systemd-binfmt (code=exited, status=0/SUCCESS)
   Main PID: 17543 (code=exited, status=0/SUCCESS)

Sep 05 21:33:20 291510-thinkbook systemd[1]: Starting Set Up Additional Binary Formats...
Sep 05 21:33:20 291510-thinkbook systemd[1]: Finished Set Up Additional Binary Formats.
~~~

之后通过 `osc` 本地构建。

~~~shell
osc co openEuler:24.03/man-db #拉取软件包配置目录，在本地会创建一个相同目录
cd openEuler:24.03/man-db
osc up -S man-db #这一步是更新文件，如果没有更新源码和spec文件可以不执行
rm -f _service;for file in `ls`;do new_file=${file##*:};mv $file $new_file;done #重命名文件，删除_service 前缀
osc build --local-package mainline_riscv64 riscv64
~~~

编译到中间报错

~~~shell
[ 1093s] Can't locate File/Basename.pm:   /usr/lib64/perl5/vendor_perl/File/Basename.pm: Permission denied at /usr/share/perl5/vendor_perl/Locale/Po4a/Po.pm line 124.
[ 1093s] BEGIN failed--compilation aborted at /usr/share/perl5/vendor_perl/Locale/Po4a/Po.pm line 124.
[ 1093s] Compilation failed in require at /usr/share/perl5/vendor_perl/Locale/Po4a/TransTractor.pm line 24.
[ 1093s] BEGIN failed--compilation aborted at /usr/share/perl5/vendor_perl/Locale/Po4a/TransTractor.pm line 24.
[ 1093s] Compilation failed in require at /usr/bin/po4a line 701.
[ 1093s] BEGIN failed--compilation aborted at /usr/bin/po4a line 701.
[ 1093s] make[3]: *** [Makefile:1787: all-local] Error 13
[ 1093s] make[3]: Leaving directory '/home/abuild/rpmbuild/BUILD/man-db-2.11.2/man/po4a'
[ 1093s] make[2]: *** [Makefile:2046: all-recursive] Error 1
[ 1093s] make[1]: *** [Makefile:1757: all-recursive] Error 1
[ 1093s] make: *** [Makefile:1689: all] Error 2
[ 1093s] error: Bad exit status from /var/tmp/rpm-tmp.EH6Ntu (%build)
~~~

参考别人的 pr， 将 `vm-type` 改成 `chroot`  修改后报错没了。再次编译顺利通过。编译结果如下（ 怀疑 `nspawn` 的报错和 `perl5` 的路径映射有关系。具体的原因还需要深究）

![image-20240906024344431](http://gu-typora-picture.oss-cn-beijing.aliyuncs.com/img/image-20240906024344431.png)

构建速度确实快了。约 400s 的速度提升。



### 参考资料

- [EulerMaker 主页](https://build.openeuler.openatom.cn/project/show/openEuler:Mainline:RISC-V)
- [QEMU 官网](https://www.qemu.org/download/)
- [openEuler 24.03 LTS RISC-V 镜像下载](https://repo.openeuler.org/openEuler-24.03-LTS/virtual_machine_img/riscv64/)
- [neofetch GitHub 仓库](https://github.com/dylanaraps/neofetch)
- [openEuler 系统下 neofetch 安装教程](https://cloud.tencent.com/developer/article/2442853)
- [OBS 简介](https://github.com/openeuler-riscv/oerv-team/blob/main/Intern/FAQ.md#什么是-obs)
- [EulerMaker OBS 网站](https://build.tarsier-infra.isrc.ac.cn/)
- [osc 工具使用文档](https://www.openbuildservice.org/help/manuals/obs-user-guide/cha.osc.html)
- [SSL 证书问题解决讨论](https://bbs.archlinux.org/viewtopic.php?id=266777)
- [systemd-timesyncd 安装与配置](https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/configuring_basic_system_settings/managing-time-services-with-systemd-timesyncd_configuring-basic-system-settings)
- [man-db 软件包构建示例](https://build.tarsier-infra.isrc.ac.cn/project/show/openEuler:24.03/man-db)
- [实习生李英凯的PRETASK任务](https://github.com/openeuler-riscv/oerv-team/pull/995)
- [实习生陈志康+创建邮箱 ](https://github.com/openeuler-riscv/oerv-team/pull/292)

* [基于 systemd-nspawn 和 QEMU User Mode 搭建 openEuler RISC-V 软件包的快速开发环境](https://zhuanlan.zhihu.com/p/528373554)

* [zypper 使用方法m)](https://www.cnblogs.com/ericte/p/13969287.html)