### PR TITLE
实习生邱文键+创建邮箱

### DIFF
--- a/Intern/intern_message.md
+++ b/Intern/intern_message.md
@@ -273,3 +273,12 @@ github：@YingkaiLi-VM
 
 邮箱：<yingkai.oerv@isrc.iscas.ac.cn>
 
+## 邱文键
+
+gitee：@chebyshevtst
+
+github：@Thomas134
+
+加入时间：2024年9月12日
+
+邮箱：


### PR DESCRIPTION
**Pre Task**

**任务一**
通过 QEMU 仿真 RISC-V 环境并启动 openEuler RISC-V 系统，设法输出 neofetch 结果并截图提交

由于我个人的Linux上面已经安装了Qemu，这里就先跳过Qemu安装的步骤，对于neofetch，直接在OpenEuler上面输入命令
```shell
dnf install neofetch
```  
即可。

 直接运行neofetch，见下图。
![26719f08b0273c2cc6e362e317fcc84](https://github.com/user-attachments/assets/3c7f5bc3-60ca-48ef-86e8-43eea7f1c5e6)

**任务二**
在 openEuler RISC-V 系统上通过 obs 命令行工具 osc，从源代码构建 RISC-V 版本的 rpm 包，比如 pcre2。（提示首先需要在 openEuler的 OBS[什么是 OBS？](https://github.com/openeuler-riscv/oerv-team/blob/main/Intern/FAQ.md#%E4%BB%80%E4%B9%88%E6%98%AF-obs) 上注册账号 [https://build.openeuler.openatom.cn/project/show/openEuler:Mainline:RISC-V）](https://build.openeuler.openatom.cn/project/show/openEuler:Mainline:RISC-V%EF%BC%89)

在注册完账号之后，运行命令
```shell
dnf install osc build
osc who
``` 
第一个命令是安装osc相关的包，第二个命令是查看目前osc配置相应的用户。（在输入第二个命令之前先在./config/osc/下的oscrc文件进行相应的配置）
```
[general]
# Default URL to the API server.
# Credentials and other `apiurl` specific settings must be configured in a `[$apiurl]` config section.
apiurl= https://build.tarsier-infra.isrc.ac.cn/
no_verify=1

[https://build.tarsier-infra.isrc.ac.cn/]
# aliases=
# user=
# pass=
# credentials_mgr_class=osc.credentials...
user=username
pass=password
``` 
不过我遇到在输入第二个命令的时候遇到了时钟同步的问题。
```
'[SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: certificate is not yet valid (_ssl.c:1006)'))) - skipping
``` 
在参考了ChatGPT给出的回复之后，我自己输入了timedatectl命令查看时钟，果然是跟宿主机没有同步，于是输入
```shell
timedatectl set-ntp true
``` 
问题便解决了。
![fa76583381bf510fa9645c6a5360e0b](https://github.com/user-attachments/assets/7f52cef1-b33e-4c40-836f-43a68e762bda)

接下来是rpm包的构建过程。
```shell
osc co openEuler:24.03/pcre2
cd openEuler:24.03/pcre2
osc up -S man-db
rm -f _service;for file in `ls`;do new_file=${file##*:};mv $file $new_file;done
osc build --local-package mainline_riscv64 riscv64
``` 
事实上，我分别对pcre2和man-db都进行了构建，在openEuler上面都构建成功了，但是pcre2在任务三构建的测试过程当中core-dump了，于是我先暂时跳过了，暂时还没有深究。
![ed3177c88a4fa7f915fb4960faf55ae](https://github.com/user-attachments/assets/4946dbc1-03ab-40f8-a800-412e05a09922)
构建man-db成功的截图。

**任务三**
尝试使用 qemu user & nspawn 或者 docker 加速完成任务二

有关qemu的配置可以看这个链接里面的文章：[https://blog.251.sh/use-qemu-user-mode-to-build-openeuler-risc-v-packages](url)。
然后是osc，obs，以及nspawn的下载。

osc的安装
```shell
git clone https://github.com/openSUSE/osc.git
cd osc
chmod +x setup.py
./setup.py build
sudo ./setup.py install
``` 

obs的安装
```shell
git clone https://github.com/openSUSE/obs-build.git
cd obs-build
sudo make install
``` 

nspawn的安装
```shell
sudo apt install systemd-container
``` 
![e71205e7437ab3ea341c497ec0e9a2b](https://github.com/user-attachments/assets/65828f9d-6559-4bbf-aca4-272039d2dabc)
systemd-container已经包含了nspawn，所以直接下载systemd-container就行。

构建步骤和任务二也基本一致，不过我第一次构建失败了，于是通过日志分析问题
![cbc77a6561e85060d3649432b31b459](https://github.com/user-attachments/assets/1e7734d8-daca-4bd5-ae4a-30b037a7f124)

我注意到了其中的Qemu路径，因为我自己电脑上面原本安装的Qemu并不是在bin路径，所以我去修改了binfmt.d下面的文件。
![154278fb951ea749ec0069ced2995f9](https://github.com/user-attachments/assets/96706382-5c24-4c18-af0a-be670208e25c)
将Qemu的路径改为正确的路径即可。

接下来是构建，如果使用nspawn进行构建，命令跟任务二的基本相同，只需要稍作修改
```shell
osc co openEuler:24.03/man-db
cd openEuler:24.03/man-db
osc up -S man-db
rm -f _service;for file in `ls`;do new_file=${file##*:};mv $file $new_file;done
osc build --local-package mainline_riscv64 riscv64 --vm-type=nspawn
``` 

构建结果如下图，速度提升了约300s。
![daecd62c8131982c1e81f1472b4723d](https://github.com/user-attachments/assets/614df3d8-c491-403f-8da2-9520b1883b0f)
