### PR TITLE
实习生袁驰程+创建邮箱

### DIFF
--- a/Intern/intern_message.md
+++ b/Intern/intern_message.md
@@ -323,3 +323,13 @@ github：@KrealHtz
 加入时间：2024年10月26日
 
 邮箱：<hongtao.oerv@isrc.iscas.ac.cn>
+
+## 袁驰程
+
+gitee: @Gensou-Link
+
+github: @Inversewing
+
+加入时间: 2024年12月12日
+
+邮箱: <chicheng.oerv@isrc.iscas.ac.cn> 


### PR DESCRIPTION
**环境**

- Ubuntu22.04LTS
- qemu 9.2.50
- openEuler 24.03LTS RISCV

**pretask**
- 任务一：通过 QEMU 仿真 RISC-V 环境并启动 openEuler RISC-V 系统，设法输出 neofetch 结果并截图提交
由于之前使用mugen时已经配置好qemu+openeuler环境，这里就不再安装。
下载[neofetch源码](https://github.com/dylanaraps/neofetch)构建
输出结果如下：
![b9c9ac7a4e999e75a1264871dd467ca8](https://github.com/user-attachments/assets/6e646767-0a62-47ab-ad1e-3b1cc53f8e52)

- 任务二：在 openEuler RISC-V 系统上通过 obs 命令行工具 osc，从源代码构建 RISC-V 版本的 rpm 包，比如 pcre2。（提示首先需要在 openEuler的 [OBS上注册账号 ](https://build.openeuler.openatom.cn/project/show/openEuler:Mainline:RISC-V%EF%BC%89)
启动openEuler环境
`osc co openEuler:24.03 pcre2`
cd进入pcre2文件夹`osc up -S`
执行`rm -f _service;for file in 'ls';do new_file=${file##*:};mv $file $new_file;done`去掉_service头
使用pcre2包，使用`osc build standard_riscv64 riscv64`报错
![QQ_1734251620266](https://github.com/user-attachments/assets/816925ca-08e8-4555-b325-3a0f46aee1d1)
正确的仓库名应该是mainline_riscv64
运行`osc build mainline_riscv64 riscv64`
 ![83A4D17F747AA83FEC2DB2C8492972A3](https://github.com/user-attachments/assets/0cee1ddf-5cf2-4ab7-8822-587de94fa0f6)
 查看/RPM/文件夹，软件包正确构建
- ​ 参考资料：
[oerv-pretask（二）](https://blog.csdn.net/weixin_52230326/article/details/135311782)

- 任务三：尝试使用 qemu user & nspawn 或者 docker 加速完成任务二
WSL2环境下无法启动systemd-binfmt.servicefu服务
![QQ_1734252252718](https://github.com/user-attachments/assets/d3c97c88-3e59-4e62-a41f-98bbe3eefa75)
于是配置了新的vmware虚拟机，发行版本保持一致
配置完成工作流之后在Ubuntu22.04LTS上执行
`osc build mainline_riscv64 riscv64 --vm-type=nspawn`
![3d5e2decc7bbc75ffc64898967fb76b4](https://github.com/user-attachments/assets/63183982-d15b-4789-a765-9422654eb147)
发现循环依赖问题会比WSL2上多，以及会提示` Can't locate Digest/SHA.pm in @INC (you may need to install the Digest::SHA module) (@INC entries checked: /.build /usr/local/lib64/perl5 /usr/local/share/perl5`
安装相应哈希模块配置Path变量之后问题依旧，但是不影响打包。
综合下来vmware虚拟机上nspawn加速之后跟wsl2上无加速速度没有特别明显的差别，应该是由于我分配给虚拟机的cpu内核数量不够多
- ​ 参考资料：
[oerv-pretask（三）](https://blog.csdn.net/weixin_52230326/article/details/135319729)