### PR TITLE
实习生施安吉+创建邮箱

### DIFF
--- a/Intern/intern_message.md
+++ b/Intern/intern_message.md
@@ -342,4 +342,4 @@ github: @Shianji
 
 加入时间: 2024年12月12日
 
-邮箱: <Shianji.oerv@isrc.iscas.ac.cn>
+邮箱: <anji.oerv@isrc.iscas.ac.cn>

--- a/Intern/intern_message.md
+++ b/Intern/intern_message.md
@@ -333,3 +333,13 @@ github: @Inversewing
 加入时间: 2024年12月12日
 
 邮箱: <chicheng.oerv@isrc.iscas.ac.cn> 
+
+## 施安吉
+
+gitee: @Shianji
+
+github: @Shianji
+
+加入时间: 2024年12月12日
+
+邮箱: <Shianji.oerv@isrc.iscas.ac.cn>


### PR DESCRIPTION
### OERV实习_PRETASK

**环境**

- WSL2 Ubuntu22.04LTS
- qemu 9.1.0
- openEuler 24.03LTS RISCV

**任务一**

- 任务一：通过 QEMU 仿真 RISC-V 环境并启动 openEuler RISC-V 系统，设法输出 neofetch 结果并截图提交。
在之前的mugen笔试环节，参考[通过QEMU 仿真 RISC-V 环境并启动 openEuler RISC-V 系统](https://www.openeuler.org/zh/blog/phoebe/2023-09-26-Run-openEuler-RISC-V-On-Qemu.html)的教程，已经编译并安装了qemu-system-riscv 9.1.0，并获取了openEuler-24.03镜像，所以可以直接启动openEuler RISC-V 系统，如下图所示：
![image](https://github.com/user-attachments/assets/743ffebe-e97c-4225-aad1-6a52e1423056)
进入openEuler-24.03后尝试直接用`dnf install neofetch`安装neofetch，报错找不到对应的包，便下载源码编译安装。首先安装make和git：`dnf install git make`，然后依次执行以下命令，拉取neofetch源码并编译安装：
  ```
  git clone https://github.com/dylanaraps/neofetch.git
  cd neofetch
  make install
  ```
  而后执行neofetch结果如下图：
  ![image](https://github.com/user-attachments/assets/597916b7-9032-4923-8806-195f2471a023)

**任务二**

- 任务二：在 openEuler RISC-V 系统上通过 obs 命令行工具 osc，从源代码构建 RISC-V 版本的 rpm 包，比如 `pcre2`。
**OBS**：全称 Open Build Service，是一个开源的软件构建和发布系统，主要用于构建和分发软件包，支持多种操作系统和硬件架构。 openEuler 的 OBS 系统分支于 openSUSE，承载了 openEuler 社区所有公开发布的软件包的构建和管理。 osc 是 OBS 的命令行客户端，可以帮助开发者在本地拉取 OBS 软件环境进行构建。
首先注册obs账号（注册地址为：[Welcome to 开源软件构建与测试](https://build.tarsier-infra.isrc.ac.cn/)），而后参考[oerv-pretask（二）在 openEuler RISC-V 系统上通过 obs 命令行工具 osc，从源代码构建 RISC-V 版本的 rpm 包，比如 coreutils](https://openatomworkshop.csdn.net/663d9cf1e7b85f1560d0d1bc.html)在本地构建pcre2的rpm包。
首先在本地创建配置文件`~/.config/osc/oscrc`，向文件中写入以下内容：
  ```
  [general]
  apiurl = https://build.tarsier-infra.isrc.ac.cn/
  no_verify = 1

  [https://build.tarsier-infra.isrc.ac.cn/]
  user=Shianji
  pass=
  ```
  接着依次执行以下命令安装osc：
  ```
  git clone https://github.com/openSUSE/osc.git
  cd osc
  chmod +x setup.py
  ./setup.py build
  sudo ./setup.py install 
  ```
  安装过程中，因为SSL认证失败导致安装报错，如下图：
  ![image](https://github.com/user-attachments/assets/ce2dfd0d-15a7-468f-9054-1001929acde9)
  查阅资料发现可能是因为时钟不匹配，使用`timedatactl set-ntp true`命令设置时钟，报错：`Failed to set ntp: NTP not supported`，使用`dnf install systemd-timesyncd`命令安装NTP服务后重新使用`timedatactl set-ntp true`命令设置时钟，时钟设置成功。如下图所示：
  ![image](https://github.com/user-attachments/assets/8555d601-0974-4f90-b59e-afdfed3ca906)
  重新执行`sudo ./setup.py install` 命令，发现缺少gcc工具和一些其他的包，获取这些包之后再次执行`sudo ./setup.py install `即可成功安装osc。
  然后依次执行以下命令安装obs-build：
  ```
  git clone https://github.com/openSUSE/obs-build.git
  cd obs-build
  sudo make install
  ```
  安装之后，进行rpm包的构建。首先将obs平台的分支的包拉下来，拉取命令为`osc co openEuler:24.03 pcre2`，这只是拉下来了一个文件_service，我们还需要一行命令来将远程包的其他相关文件一起拉下来，进入`openEuler:24.03/pcre2 `目录后执行`osc up -S`进行拉取， 我们拉下来的文件都是_service开头的，这是不可用的，所以我们还需要去掉这些头，命令如下：
  ```
  rm -f _service;for file in `ls`;do new_file=${file##*:};mv $file $new_file;done
  ```
  最后，就可以尝试进行构建rpm包了，输入命令`osc build standard_riscv64 riscv64`，发现报错：
  ![image](https://github.com/user-attachments/assets/c7e3b970-ce1a-42d0-baf3-ac4d80c3546a)
  改用命令`osc build mainline_riscv64 riscv64`后成功构建，结果如下图：
  ![image](https://github.com/user-attachments/assets/e8817ca5-3499-457a-a452-f504d3d09d68)

**任务三**

- 任务三：尝试使用 qemu user & nspawn 或者 docker 加速完成任务二
**chroot**： 是 Linux 系统中的一个命令，用于将进程的根文件系统更改为指定的目录，从而实现对系统的局部隔离。它通过改变进程的根目录 (/) 来限制该进程只能访问指定的目录树，无法访问其他系统部分。chroot 常用于创建沙箱环境，但其隔离性较弱，无法防止进程获取主机系统的信息。
**systemd-nspawn**：是 systemd 提供的工具，用于启动容器式的轻量级虚拟化环境。它通过类似于 chroot 的方式提供文件系统隔离，并支持网络、进程等资源的隔离，比 chroot 更加安全。nspawn 通常用于测试和构建隔离环境，且具备更多的功能和控制。
参考[oerv-pretask（三）基于 systemd-nspawn 和 QEMU User Mode 搭建 openEuler RISC-V 软件包的快速开发环境](https://blog.csdn.net/weixin_52230326/article/details/135319729)，首先是安装qemu-sicv64，因为之前已经下载过qemu源码，所以进入qemu目录后依次执行以下命令编译安装即可：
  ```
  ./configure --target-list=riscv64-linux-user --enable-user
  make -j $(nproc)
  sudo make install
  ```
  然后是和任务二一样依次执行以下命令安装osc和obs-build：
  ```
  #安装osc
  git clone https://github.com/openSUSE/osc.git
  cd osc
  chmod +x setup.py
  ./setup.py build
  sudo ./setup.py install 
  #安装obs-build
  git clone https://github.com/openSUSE/obs-build.git
  cd obs-build
  sudo make install
  ```
  安装之后，依次执行以下命令拉取远程包：
  ```
  osc co openEuler:24.03 pcre2
  osc up -S                         #进入openEuler:24.03/pcre2 目录后执行
  rm -f _service;for file in `ls`;do new_file=${file##*:};mv $file $new_file;done
  ```
  接着执行`sudo apt install systemd-container`安装nspawn，安装完成执行`sudo systemctl status systemd-binfmt.service`进行检查，输出的状态为active（绿色）表示正常。然后执行`osc build mainline_riscv64 riscv64 --vm-type=nspawn`在本地进行构建时又报错提示一些软件包依赖缺失，根据提示执行`sudo apt install qemu-user-static rpm rpm2cpio `进行安装，再次执行仍然报错，如下图：
  ![image](https://github.com/user-attachments/assets/436fe223-485a-4893-ad73-8a0b12ef1dcf)
  提示文件没有权限，但一开始并没有找到对应的文件，便尝试使用chroot进行构建，执行`osc build mainline_riscv64 riscv64 --vm-type=chroot`，构建成功结构如下图：
  ![image](https://github.com/user-attachments/assets/13e5b3d2-b9e1-42cc-bf47-f84a8e45e0f6)
  构建时间从1050 S加速至432 S。
  参考其他同学的PR，发现有在用nspawn构建过程中遇到和我同样的报错，参考[实习生顾凯杰+创建邮箱](https://github.com/openeuler-riscv/oerv-team/pull/1334)后得知，使用nspawn进行构建时，报错的文件是相对路径，找到源文件并手动赋予权限后，再次执行`osc build mainline_riscv64 riscv64 --vm-type=nspawn`构建成功，如下图所示：
  ![image](https://github.com/user-attachments/assets/2cf1f188-7254-45e1-85e8-c0e2941b01ec)
  耗时392 S，用nspawn构建比用chroot更快。
