### PR TITLE
实习生张天泽+创建邮箱

### DIFF
--- a/Intern/intern_message.md
+++ b/Intern/intern_message.md
@@ -374,3 +374,13 @@ github: @yqthz
 加入时间: 2025年3月24日
 
 邮箱: <senlin.oerv@isrc.iscas.ac.cn>
+
+## 张天泽
+
+gitee: @delta-gitee
+
+github: @Delta-in-hub
+
+加入时间: 2025年4月7日
+
+邮箱: <tianze.oerv@isrc.iscas.ac.cn>


### PR DESCRIPTION
# pretask

> https://github.com/openeuler-riscv/oerv-team/blob/main/Intern/guide.md



宿主机环境:

```
OS: Manjaro Linux x86_64
Kernel: Linux 6.12.20-2-MANJARO
Shell: zsh 5.9
DE: KDE Plasma 6.3.3
WM: KWin (Wayland)
Terminal: konsole 24.12.3
CPU: 12th Gen Intel(R) Core(TM) i7-12700 (20) @ 4.90 GHz
```







## 任务一

>  任务一：通过 QEMU 仿真 RISC-V 环境并启动 openEuler RISC-V 系统，设法输出 neofetch 结果并截图提交



**部署环境**



访问 [Openeuler官网](https://www.openeuler.org/zh/download/#openEuler%2025.03), 选择 openEuler 24.03 LTS SP1 ->  RISC-V -> 云计算,  下载所有的软件包. 

下载后解压 `xz -dk openEuler-24.03-LTS-SP1-riscv64.qcow2.xz`



宿主机上已经提前安装了 QEMU 环境,  具体参考 [Archlinux Wiki](https://wiki.archlinux.org/title/QEMU).

运行 qemu `bash start_vm.sh`.



登陆时, 根据 [Documentation](https://docs.openeuler.org/en/docs/24.03_LTS_SP1/docs/Releasenotes/account-list.html), openEuler VM image 的默认user/passwd 为 `root` 和 `openEuler12#$`.


![image](https://github.com/user-attachments/assets/10d301ee-82db-434d-8297-9c03bbc1e173)


根据`start_vm.sh` , 其会把Qemu跑起来的ssh port 映射到本机的 `12055` 端口.

为了方便使用, 使用宿主机的terminal进行连接, 编辑 `~/.ssh/config` , 添加
```
Host oerv
	HostName localhost
	User root
	Port 12055
```



使用 `ssh-copy-id oerv` 拷贝本机公钥到Qemu的openeuler 中, 以免密钥登陆.





**运行 neofetch**



首先安装 wget `dnf install -y wget` , 该过程出现以下错误

```
  - Curl error (60): SSL peer certificate or SSH remote key was not OK for https://repo.openeuler.openatom.cn/openEuler-24.03-LTS-SP1/update/source/repodata/repomd.xml [SSL certificate problem: certificate is not yet valid]
```

解决方法是: 需要正确同步系统时间, 安装 `dnf install -y systemd-timesyncd` 然后使用 `timedatectl set-ntp yes` 开启 ntp 时间同步.

使用 `timedatectl set-time` 先手动修改时间.



然而这一过程出现以下错误:

```
[root@localhost ~]# dnf install -y systemd-timesyncd
OS                                                                                             12 kB/s |  26 kB     00:02    
OS                                                                                            0.0  B/s |   0  B     00:01    
Errors during downloading metadata for repository 'OS':
  - Curl error (7): Couldn't connect to server for https://repo.openeuler.org/openEuler-24.03-LTS-SP1/OS/riscv64/repodata/repomd.xml [Failed to connect to repo.openeuler.org port 443 after 55 ms: Couldn't connect to server]
  - Curl error (7): Couldn't connect to server for https://repo.openeuler.org/openEuler-24.03-LTS-SP1/OS/riscv64/repodata/repomd.xml [Failed to connect to repo.openeuler.org port 443 after 0 ms: Couldn't connect to server]
  - Status code: 404 for https://mirrors.openeuler.org/metalink?repo=24.03LTS_SP1/OS&arch=riscv64 (IP: 49.0.229.174)
Error: Failed to download metadata for repo 'OS': Cannot download repomd.xml: Cannot download repodata/repomd.xml: All mirrors were tried
```

网络正常的情况下, 不能够连接到 `repo.openeuler.org`, `ping repo.openeuler.org`:

```
[root@localhost ~]# ping repo.openeuler.org
PING repo.openeuler.org (127.0.0.1) 56(84) bytes of data.
64 bytes from localhost (127.0.0.1): icmp_seq=1 ttl=64 time=1.47 ms
64 bytes from localhost (127.0.0.1): icmp_seq=2 ttl=64 time=0.262 ms
```

显示 `repo.openeuler.org` 被DNS服务器解析到了 localhost.

编辑一下 `/etc/resolv.conf` , 使用腾讯云的public dns `119.29.29.29` , 重新进行以上步骤, 一切正常.





**注: 不要使用阿里的dns**  

> Qemu的该镜像中, 会使用宿主机的DNS服务器, 我在宿主机上部署了Adguard Home, 使用了阿里的DNS服务器.
>
> 但是, 阿里的公共DNS 会把 `repo.openeuler.org` 域名解析到 `127.0.0.1`....... 不过这可能和运营商有关系.

```

❯ dig repo.openeuler.org @223.5.5.5
; <<>> DiG 9.20.7 <<>> repo.openeuler.org @223.5.5.5
;; global options: +cmd
;; Got answer:
;; ->>HEADER<<- opcode: QUERY, status: NOERROR, id: 50295
;; flags: qr rd ra; QUERY: 1, ANSWER: 1, AUTHORITY: 0, ADDITIONAL: 1

;; OPT PSEUDOSECTION:
; EDNS: version: 0, flags:; udp: 1232
;; QUESTION SECTION:
;repo.openeuler.org.            IN      A

;; ANSWER SECTION:
repo.openeuler.org.     2211    IN      A       127.0.0.1

;; Query time: 56 msec
;; SERVER: 223.5.5.5#53(223.5.5.5) (UDP)
;; WHEN: Sun Apr 06 18:47:26 CST 2025
;; MSG SIZE  rcvd: 63

```





下载 neofetch



`wget https://cf.ghproxy.cc/https://github.com/dylanaraps/neofetch/archive/refs/tags/7.1.0.zip`

并解压

`unzip 7.1.0.zip `



![image](https://github.com/user-attachments/assets/556edad4-e359-462b-9b74-08edfd2f263e)





## 任务二

> 任务二：在 openEuler RISC-V 系统上通过 obs 命令行工具 osc，从源代码构建 RISC-V 版本的 rpm 包，比如 `pcre2`。





在 Qemu 中安装 osc `dnf install -y osc --disablerepo=update-source`

```
mkdir -p ~/.config/osc/
vim ~/.config/osc/oscrc
```



填入：

```
[general]
apiurl = https://build.tarsier-infra.isrc.ac.cn/
no_verify = 1

[https://build.tarsier-infra.isrc.ac.cn]
user=
pass=
credentials_mgr_class=osc.credentials.PlaintextConfigFileCredentialsManager
```





- `osc co openEuler:24.03:SP1:Everything pcre2`, 拉取对应版本的 pcre2 

- `cd openEuler:24.03:SP1:Everything/pcre2/ `
- `osc up -S `
- `rm -f _service;for file in `ls`;do new_file=${file##*:};mv $file $new_file;done`
- `dnf install -y --disablerepo=update-source build`  , 安装构建相关的依赖
- `osc build standard_riscv64 riscv64`




![image](https://github.com/user-attachments/assets/faa3975a-eb56-4158-9231-cbf551fe817b)





## 任务三

> 任务三：尝试使用 qemu user & nspawn 或者 docker 加速完成任务二



以下均是在宿主机下操作。



宿主机上安装 `paru -S qemu-user-static qemu-user-static-binfmt osc obs-build rpm`



重复步骤二中配置 osc 的过程, 然后 ` osc build standard_riscv64 riscv64 --vm-type=chroot  `


![image](https://github.com/user-attachments/assets/1dbadf10-ce6a-4709-8e8f-c4d805d7e7fa)

![image](https://github.com/user-attachments/assets/fa971ae6-a568-44c8-87f9-955f57aee16f)








参考:

https://blog.csdn.net/weixin_52230326/article/details/135319729







