### PR TITLE
实习生刘颜铭+创建邮箱

### DIFF
--- a/Intern/intern_message.md
+++ b/Intern/intern_message.md
@@ -454,3 +454,13 @@ github: @JoeyLYL
 
 邮箱: <yilin.oerv@isrc.iscas.ac.cn> 
 
+## 刘颜铭
+
+gitee: @liuym2022
+
+github: @liu20222
+
+加入时间: 2025年4月29日
+
+邮箱:<yanming.oerv@isrc.iscas.ac.cn>
+


### PR DESCRIPTION
## 任务一：通过 QEMU 仿真 RISC-V 环境并启动 openEuler RISC-V 系统，设法输出 fastfetch 结果并截图提交
### 环境

* Ubuntu 22.04.5 LTS
* QEMU emulator version 8.1.2
* openEuler 24.03 (LTS-SP1)

参考：[RISC-V安装指南（24.03 LTS SP1）](https://docs.openeuler.org/zh/docs/24.03_LTS_SP1/docs/Installation/RISC-V-QEMU.html)、[RISC-V安装指南（版本: 23.09）](https://docs.openeuler.org/zh/docs/23.09/docs/Installation/riscv_qemu.html)、[通过 QEMU 仿真 RISC-V 环境并启动 OpenEuler RISC-V 系统](https://gitee.com/openeuler/RISC-V/blob/master/doc/tutorials/vm-qemu-oErv.md)

第一次安装了openEuler 23.09，无法使用 dnf。运行：
```
dnf install fastfetch -y
```

报错：
```
Errors during downloading metadata for repository 'everything':
  - Status code: 404 for https://mirrors.openeuler.org/metalink?repo=23.09/everything&arch=riscv64 (IP: 49.0.229.174)
  - Status code: 404 for https://dl-cdn.openeuler.openatom.cn/openEuler-23.09/everything/riscv64/repodata/repomd.xml (IP: 58.205.215.145)
Error: Failed to download metadata for repo 'everything': Cannot download repomd.xml: Cannot download repodata/repomd.xml: All mirrors were tried
```
为了后续方便，换成了openEuler 24.03 (LTS-SP1)。
### 安装支持 RISC-V 架构的 QEMU 模拟器
使用 
```
sudo apt install qemu-system-misc
```
安装成功 (QEMU emulator version 6.2.0)。但网页上写 *由于 QEMU 8.0 及更新版本提供了大量针对 RISC-V 的修复和更新，我们推荐使用 QEMU 8.0 或更新版本以获得更佳体验。* 故手动编译安装

```
wget https://download.qemu.org/qemu-8.1.2.tar.xz
tar -xvf qemu-8.1.2.tar.xz
cd qemu-8.1.2
mkdir res
cd res
sudo apt install libspice-protocol-dev libepoxy-dev libgtk-3-dev libspice-server-dev build-essential autoconf automake autotools-dev pkg-config bc curl gawk git bison flex texinfo gperf libtool patchutils mingw-w64 libmpc-dev libmpfr-dev libgmp-dev libexpat-dev libfdt-dev zlib1g-dev libglib2.0-dev libpixman-1-dev libncurses5-dev libncursesw5-dev meson libvirglrenderer-dev libsdl2-dev -y
../configure --target-list=riscv64-softmmu,riscv64-linux-user --prefix=/usr/local/bin/qemu-riscv64 --enable-slirp
make -j$(nproc)
sudo make install
```
将 /usr/local/bin/qemu-riscv64/bin 添加至 $PATH 。
```
echo 'export PATH=/usr/local/bin/qemu-riscv64/bin:$PATH' >> ~/.bashrc
source ~/.bashrc
```

### 准备 openEuler RISC-V 磁盘映像
下载所需的文件，执行校验
```
sha256sum -c openEuler-24.03-LTS-SP1-riscv64.qcow2.xz.sha256sum 
```


### 启动 openEuler RISC-V 虚拟机
* 解压映像压缩包 
```
xz -dk openEuler-24.03-LTS-SP1-riscv64.qcow2.xz
```
* 启动虚拟机
```
bash start_vm_penglai.sh
```

* 用ssh登录，开一个新的终端
```
ssh -p 12055 root@localhost
```
密码
```
openEuler12#$
```
### 设法输出 fastfetch 结果并截图提交
手动编译安装：
```
dnf install git cmake gcc gcc-c++ make 
git clone https://github.com/fastfetch-cli/fastfetch.git
cd fastfetch
mkdir build
cd build
cmake ..
make -j$(nproc)
make install
fastfetch
```

#### 遇到的报错： SSL 证书问题，证书无效。（猜测是虚拟机系统时间不对）
```
fatal: unable to access 'https://github.com/fastfetch-cli/fastfetch.git/': SSL certificate problem: certificate is not yet valid
```
手动同步时间（不用太精确），解决
```
date -s "2025-04-28 22:30:00"
```

#### 安装成功，如图：
![task1](https://github.com/user-attachments/assets/715f17b0-b940-4fcc-8f4a-ef6232f027b5)

## 任务二：在 openEuler RISC-V 系统上通过 obs 命令行工具 osc，从源代码构建 RISC-V 版本的 rpm 包，比如 pcre2。（提示首先需要在 openEuler的 OBS什么是 OBS？ 上注册账号 https://build.tarsier-infra.isrc.ac.cn ）

先注册 OBS 账号 https://build.tarsier-infra.isrc.ac.cn/

```
dnf install osc
mkdir -p ~/.config/osc
vim ~/.config/osc/oscrc
[general]
apiurl = https://build.tarsier-infra.isrc.ac.cn/
no_verify = 1

[https://build.tarsier-infra.isrc.ac.cn/]
user= OBS的用户名
pass= OBS的密码
```
在 https://build.tarsier-infra.isrc.ac.cn/ 将openEuler:24.03:SP1:Everything / pcre2取到自己home工程下。之后在虚拟机上
```
osc co home:liuym2022:branches:openEuler:24.03:SP1:Everything
cd home:liuym2022:branches:openEuler:24.03:SP1:Everything/pcre2
osc up -S
rm -f _service
for file in $(ls); do new_file=${file##*:}; mv "$file" "$new_file"; done
osc build standard_riscv64 riscv64
```
![task2](https://github.com/user-attachments/assets/4e1d3557-af66-427f-a457-b46ab6281d6f)

### 任务三：尝试使用 qemu user & nspawn 或者 docker 加速完成任务二
参考：左敬源同学的记录 [实习生左敬源+创建邮箱](https://github.com/openeuler-riscv/oerv-team/pull/1736)

执行
```
sudo ./scripts/qemu-binfmt-conf.sh --persistent yes --credential yes --systemd riscv64
sudo systemctl restart systemd-binfmt 

vim ~/.config/osc/oscrc
[general]
apiurl = https://build.tarsier-infra.isrc.ac.cn/
no_verify = 1

[https://build.tarsier-infra.isrc.ac.cn/]
user= OBS的用户名
pass= OBS的密码

osc co home:liuym2022:branches:openEuler:24.03:SP1:Everything

osc build standard_riscv64 riscv64 --vm-type=chroot

```

报错

```
[    6s] pickle-virtual-machine failed "build pcre2.spec" at Mon Apr 28 16:19:05 UTC 2025.
[    6s] 

The buildroot was: /var/tmp/build-root/standard_riscv64-riscv64/.mount
```
检查 qemu-riscv64 是否被系统注册成功：
```
ls /proc/sys/fs/binfmt_misc/ | grep qemu
```
发现无输出（未成功），执行：
```
sudo update-binfmts --enable qemu-riscv64
```
之后重新执行
```
osc build standard_riscv64 riscv64 --vm-type=chroot
```
成功加速！
![task3](https://github.com/user-attachments/assets/9c58c757-62b5-4c80-baad-1778a1d0be2f)
