### PR TITLE
实习生鲁邦彦+创建邮箱

### DIFF
--- a/Intern/intern_message.md
+++ b/Intern/intern_message.md
@@ -433,3 +433,13 @@ github: @ayostl
 加入时间: 2025年4月14日
 
 邮箱: <xinpeng.oerv@isrc.iscas.ac.cn>
+
+## 鲁邦彦
+
+gitee: @alu-cg
+
+github: @alu-cg
+
+加入时间：2025年4月30日
+
+邮箱：


### PR DESCRIPTION
# Pretask1
开发机环境为Fedora 41 x64. QEMU版本为9.1.3.
拉好镜像直接启动即可。
![fastfetch](https://github.com/user-attachments/assets/018cd84a-51fb-4de0-90f1-729aacb300b5)

# Pretask2 在 openEuler RISC-V 系统上通过 obs 命令行工具 osc，从源代码构建 RISC-V 版本的 rpm 包，比如 `pcre2`

先按提示注册好OBS. openEuler的OBS是openSUSE obs的分支，因此文档可以去看openSUSE的。https://openbuildservice.org/files/manuals/obs-user-guide.pdf

下载好obs以后需要先改配置文件

```
[root@localhost ~]# vim /root/.config/osc/oscrc
#默认是这样
···
apiurl=https://api.opensuse.org

[https://api.opensuse.org]
···
#替换为下面的
···
apiurl = https://build.tarsier-infra.isrc.ac.cn/
no_verify = 1

[https://build.tarsier-infra.isrc.ac.cn]
···
```
创建远程分支以及拉文件到本地，并对文件重命名的操作如下
```
osc branch openEuler:Mainline:RISC-V coreutils
osc co home:root:openEuler:Maniline:RISC-V coreutils
osc up -S
rm -f _service;for file in `ls | grep -v .osc`;do new_file=${file##*:};mv $file $new_file;done
```
之后即可开始构建
`osc build`

![pretask2](https://github.com/user-attachments/assets/d649c516-9f5e-4669-b035-82f46da7324a)

# Pretask 3: 尝试使用 qemu user & nspawn 或者 docker 加速完成任务二

关于[QEMU User Mode Emulation](https://www.qemu.org/docs/master/user/index.html#user-mode-emulation) ：使用QEMU运行为另一种CPU编译的进程。相较于System Emulation, 仅虚拟CPU。

关于[systemd-nspawn](https://wiki.archlinux.org/title/Systemd-nspawn): 允许在namespace container中运行指令或OS。

首先可以将QEMU中文件系统提取到宿主机。[关于如何挂载QEMU img](https://unix.stackexchange.com/questions/268460/how-to-mount-qcow2-image)

```
sudo modprobe nbd
sudo qemu-nbd --connect=/dev/nbd0 openEuler-25.03-V1-base-qemu-testing.qcow2

$ sudo fdisk -l /dev/nbd0
Disk /dev/nbd0: 20 GiB, 21474836480 bytes, 41943040 sectors
Units: sectors of 1 * 512 = 512 bytes
Sector size (logical/physical): 512 bytes / 512 bytes
I/O size (minimum/optimal): 512 bytes / 131072 bytes
Disklabel type: gpt
Disk identifier: 42062537-9FE0-49CF-B11A-FE04D17040B4

Device        Start      End  Sectors  Size Type
/dev/nbd0p1    2048  1050623  1048576  512M BIOS boot
/dev/nbd0p2 1050624 41943006 40892383 19.5G Linux filesystem

$ sudo mount /dev/nbd0p2 /mnt/
```

完事以后unmount and disconnect的指令放在这里，不过这里还没有用完,,
```
umount /mnt
qemu-nbd --disconnect /dev/nbd0
rmmod nbd
```
关于如何使用`systemd-nspawn`以及`qemu-user`来在容器中运行不同架构的程序参考了以下博客

https://blog.oddbit.com/post/2016-02-07-systemd-nspawn-for-fun-and-wel/

`systemd-nspawn`功能与`chroot`类似，但其会顺带帮你完成一系列工作，如建立`/proc`, `/sys`等virtual file system. 同时，由于目标系统架构为RV64, 此处需要`qemu-user-static`来对cpu进行虚拟。linux 提供了一套魔法来通过二进制文件的头部判断其架构并运行（详见[binfmt-misc](https://docs.kernel.org/admin-guide/binfmt-misc.html)). 具体实现细节在上述参考连接中有详解，此处我们仅需安装`qemu-user-static`软件包
```
dnf install qemu-user-static
```
之后即可通过`systemd-nspawn`进入系统
`systemd-nspawn -D /mnt`

后续步骤与pretask2一致。

![pretask3](https://github.com/user-attachments/assets/dfd254fd-e565-451a-99be-a0c1555a1604)
