### PR TITLE
实习生杨诗睿+创建邮箱

### DIFF
--- a/Intern/intern_message.md
+++ b/Intern/intern_message.md
@@ -474,6 +474,28 @@ github: @Shao-ZW
 
 邮箱：<zhuowei.oerv@isrc.iscas.ac.cn>
 
+
+## 龚志乐
+gitee: @BI1XJT
+
+github: @goodspeed34
+
+加入时间：2025年10月21日
+
+邮箱：<gongzl.oerv@isrc.iscas.ac.cn>
+
+
+## 黄楚浩
+
+gitee: @Wb_Alpha
+
+github: @Wb-Alpha
+
+加入时间： 2025年10月9日
+
+邮箱：<chuhao.oerv@isrc.iscas.ac.cn>
+
+
 ## 杨诗睿
 gitee:@SherryShirui
 


### PR DESCRIPTION
# Pretask

#### 任务一：通过 QEMU 仿真 RISC-V 环境并启动 openEuler RISC-V 系统，设法输出 neofetch 结果并截图提交

首先需要在Linux（Ubuntu22.04.5）安装QEMU模拟器，我这里直接使用发行版提供的预编译软件包

详情可见[[release/openEuler-22.03/qemu/README.md · openEuler/RISC-V - Gitee.com](https://gitee.com/openeuler/RISC-V/blob/master/release/openEuler-22.03/qemu/README.md#https://gitee.com/link?target=https%3A%2F%2Fmirror.iscas.ac.cn%2Fopeneuler-sig-riscv%2FopenEuler-RISC-V%2Fpreview%2FopenEuler-22.03-V1-riscv64%2FQEMU%2F)](https://gitee.com/openeuler/RISC-V/blob/master/release/openEuler-22.03/qemu/README.md#https://gitee.com/link?target=https%3A%2F%2Fmirror.iscas.ac.cn%2Fopeneuler-sig-riscv%2FopenEuler-RISC-V%2Fpreview%2FopenEuler-22.03-V1-riscv64%2FQEMU%2F)

输入命令

```
sudo apt install qemu-system-misc
```

成功安装
<img width="2559" height="1599" alt="0642a4760005cc09b8600aa65f7d5d8" src="https://github.com/user-attachments/assets/6b441eb3-924f-4440-865b-af9e15bce696" />


然后在openEuler输入命令

```
dnf install neofetch
```

运行neofetch即可
<img width="1671" height="1199" alt="2054635dc1e9df55223ee56cc5d1abf" src="https://github.com/user-attachments/assets/a72d7e9b-3827-4845-bb2b-15aa25645375" />


#### 任务二：在 openEuler RISC-V 系统上通过 obs 命令行工具 osc，从源代码构建 RISC-V 版本的 rpm 包，比如 pcre2。（提示首先需要在 openEuler的 OBS[[什么是 OBS？](https://github.com/openeuler-riscv/oerv-team/blob/main/Intern/FAQ.md#%E4%BB%80%E4%B9%88%E6%98%AF-obs)](https://github.com/openeuler-riscv/oerv-team/blob/main/Intern/FAQ.md#什么是-obs) 上注册账号 https://build.openeuler.openatom.cn/project/show/openEuler:Mainline:RISC-V）

首先注册账号，我的用户名是SherryShirui

完成后运行命令

```
dnf install osc build
```

在oscrc文件进行相应的用户名和密码配置后，运行

```
osc who
```

会输出我的账号等信息

接下来构建rpm包

```
osc co openEuler:24.03/man-db
cd openEuler:24.03/man-db
osc up -S man-db
rm -f _service;for file in `ls`;do new_file=${file##*:};mv $file $new_file;done
osc build --local-package mainline_riscv64 riscv64
```

发现报错`Building API error:can't verify packages due to lack of GPG keys`
<img width="3839" height="2093" alt="512b0cbd46db060e3d64f3d793f8acd" src="https://github.com/user-attachments/assets/6459b71b-6d92-41ec-a54f-8c09cfc994d8" />


报错原因是本地 osc build 想校验依赖仓库的签名，但该 OBS 实例没有提供可用的签名公钥，导致校验失败。

于是我查询osc 官方手册，里面明确有 `--no-verify/--noverify` 选项可以跳过用 GPG key 的签名校验。

改命令为

```
osc build --no-verify --local-package mainline_riscv64 riscv64
```

问题解决，构建成功
<img width="3839" height="2159" alt="35e03196fd62158c37eeef99b290feb" src="https://github.com/user-attachments/assets/70870019-dcbd-4a6e-84b8-161289199ef6" />


#### 任务三：尝试使用 qemu user & nspawn 或者 docker 加速完成任务二

我选择采用nspawn的方法。

首先进行`osc、obs、nspawn`的安装。输入命令

```
git clone https://github.com/openSUSE/osc.git
cd osc
chmod +x setup.py
./setup.py build
sudo ./setup.py install
```

```
git clone https://github.com/openSUSE/obs-build.git
cd obs-build
sudo make install
```

```
sudo dnf install -y systemd-nspawn
```
<img width="3839" height="2159" alt="a707c468c0151a3f73bfcbaf17fc5d5" src="https://github.com/user-attachments/assets/4ee6c95e-697f-413f-9553-5ad606e2f3fe" />

构建步骤同任务二，只是命令需要改为

```
osc build --local-package mainline_riscv64 riscv64 --vm-type=nspawn
```

使用nspawn构建包成功截图
<img width="3838" height="2086" alt="114c3edf46236ae0db53fad0f2225ef" src="https://github.com/user-attachments/assets/3fc7415c-4172-45f9-a6d9-20c5246775b4" />


但是发现包构建速度不仅没有降低，反而延长了23秒。

检查日志，显示`Doing nspawn build` ，表示确实启用了 `nspawn` 模式；

`openEuler-riscv64 started "build man-db.spec" at ...` 表示通过` systemd-nspawn` 启动了容器并在其中执行构建。
<img width="1712" height="583" alt="屏幕截图 2025-10-20 112159" src="https://github.com/user-attachments/assets/79bff05d-1476-4f92-9fab-a09147d8737a" />


原因可能是我使用的这台主机就是 openEuler-riscv64，而任务三里提到的加速主要是针对在 x86 主机上用 qemu-user 跨架构构建 riscv64的情况。在这种“本机=目标架构”的场景，nspawn只是提供隔离，并不会带来可感知的加速，反而会因为容器启动与准备环境多出几十秒的开销。